### PR TITLE
Silence dotenv by default

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ module.exports = function (options) {
         if(t.isAssignmentExpression(path.parent) && path.parent.left == path.node) return;
         if (path.get("object").matchesPattern("process.env")) {
           if (!dotenv) {
-            dotenv = require('dotenv').config(Object.assign({}, state.opts, defaultOptions);
+            dotenv = require('dotenv').config(Object.assign({}, defaultOptions, state.opts);
           }
           var key = path.toComputedKey();
           if (t.isStringLiteral(key)) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,9 @@
 "use strict";
 
 var dotenv;
+var defaultOptions = {
+  silence: true
+};
 
 module.exports = function (options) {
   var t = options.types;
@@ -11,7 +14,7 @@ module.exports = function (options) {
         if(t.isAssignmentExpression(path.parent) && path.parent.left == path.node) return;
         if (path.get("object").matchesPattern("process.env")) {
           if (!dotenv) {
-            dotenv = require('dotenv').config(state.opts);
+            dotenv = require('dotenv').config(Object.assign({}, state.opts, defaultOptions);
           }
           var key = path.toComputedKey();
           if (t.isStringLiteral(key)) {

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@
 
 var dotenv;
 var defaultOptions = {
-  silence: true
+  silent: true
 };
 
 module.exports = function (options) {


### PR DESCRIPTION
Most often .dotenv is used for development or secrets so it is added to .gitignore, so I think it should be silent by default. Super O.K if you disagree.