### PR TITLE
add dotenv-expand support

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,2 @@
 EXAMPLE_ENV_VAR="simple example"
+EXAMPLE_ENV_VAR_EXPAND=$EXAMPLE_ENV_VAR-expand

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "babel-eslint": "^8.0.1",
     "babel-preset-es2015": "^6.1.18",
     "babel-register": "^6.2.0",
-    "mocha": "^4.0.1"
+    "mocha": "^4.0.1",
+    "dotenv-expand": "^4.0.1"    
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,10 @@ module.exports = function (options) {
         if (path.get("object").matchesPattern("process.env")) {
           if (!dotenv) {
             dotenv = require('dotenv').config(state.opts);
+            var dotenvExpand;
+            try { dotenvExpand = require('dotenv-expand'); } catch(e) {}
+            if (dotenvExpand)
+              dotenvExpand(dotenv);
           }
           var key = path.toComputedKey();
           if (t.isStringLiteral(key)) {

--- a/test/fixtures/code-simple-env-variable/actual.js
+++ b/test/fixtures/code-simple-env-variable/actual.js
@@ -6,6 +6,7 @@
 // A base class is defined using the new reserved 'class' keyword
 
 const EXAMPLE_ENV_VAR = process.env.EXAMPLE_ENV_VAR;
+const EXAMPLE_ENV_VAR_EXPAND = process.env.EXAMPLE_ENV_VAR_EXPAND;
 
 class Polygon {
   // ..and an (optional) custom class constructor. If one is

--- a/test/fixtures/code-simple-env-variable/expected.js
+++ b/test/fixtures/code-simple-env-variable/expected.js
@@ -6,6 +6,7 @@
 // A base class is defined using the new reserved 'class' keyword
 
 const EXAMPLE_ENV_VAR = process && process.env && process.env.EXAMPLE_ENV_VAR || "simple example";
+const EXAMPLE_ENV_VAR_EXPAND = process && process.env && process.env.EXAMPLE_ENV_VAR_EXPAND || "simple example-expand";
 
 class Polygon {
   // ..and an (optional) custom class constructor. If one is


### PR DESCRIPTION
Hi, please have a look into this PR.

I added "dotenv-expand" as devDependency to make testing possible. For users, if no "dotenv-expand" package is installed/found then you get the original behavior. Installing "dotenv-expand" in your project's package.json brings you the variable expansion functionality.

This was the easiest way to follow your "Were an optional dependency" wish :-)

I tried to implement this enhancement as isolated as possible, but this did not work out so well because the "dotenv" variable in "src/index.js" is initialized once and reused across all tests. Might make sense to change this, but would have introduces way more changes than my current PR.