### PR TITLE
Allow system vars if the systemVar option is all.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ function loadDotenvContent (opts){
     var dotenvExpand;
     try { dotenvExpand = require('dotenv-expand'); } catch(e) {}
     if (dotenvExpand)
-      dotenvContent = dotenvExpand({parsed:dotenvContent, ignoreProcessEnv:true}).parsed;
+      dotenvContent = dotenvExpand({parsed:dotenvContent, ignoreProcessEnv:opts.systemVar!=="all"}).parsed;
 }
 
 function getValue(dotenvContent, systemContent, opts, name) {


### PR DESCRIPTION
When we specify `systemVar === "all"`, allow the dot-env to load system vars as well.